### PR TITLE
allow netboot on EFI systems

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,11 +25,16 @@
     creates: '{{ ipxe_tftp_root + "/undionly.kpxe" }}'
   when: ipxe_tftp is defined and ipxe_tftp
 
+- name: Check if iPXE package contains EFI binary
+  stat:
+    path: '/usr/lib/ipxe/ipxe.efi'
+  register: ipxe_register_efi
+
 - name: Copy the iPXE efi boot binary to TFTP root directory
   command: cp /usr/lib/ipxe/ipxe.efi {{ ipxe_tftp_root + "/ipxe.efi" }}
   args:
     creates: '{{ ipxe_tftp_root + "/ipxe.efi" }}'
-  when: ipxe_tftp is defined and ipxe_tftp
+  when: ipxe_tftp is defined and ipxe_register_efi.stat.exists
 
 - name: Create iPXE configuration directory
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,12 @@
     creates: '{{ ipxe_tftp_root + "/undionly.kpxe" }}'
   when: ipxe_tftp is defined and ipxe_tftp
 
+- name: Copy the iPXE efi boot binary to TFTP root directory
+  command: cp /usr/lib/ipxe/ipxe.efi {{ ipxe_tftp_root + "/ipxe.efi" }}
+  args:
+    creates: '{{ ipxe_tftp_root + "/ipxe.efi" }}'
+  when: ipxe_tftp is defined and ipxe_tftp
+
 - name: Create iPXE configuration directory
   file:
     path: '{{ ipxe_config_root }}'


### PR DESCRIPTION
copy ipxe.efi besides undionly.efi, this file is required for net-booting on EFI based systems

See http://ipxe.org/howto/chainloading#uefi for more information

Copying an additional small file seems like little possibility for breaking something, so I did not create a config option to enable/disable this. But I will happily add this if you prefer.